### PR TITLE
Adding collapsible tree layout to the sidebar and its new CSS

### DIFF
--- a/app/css/tree.css
+++ b/app/css/tree.css
@@ -1,0 +1,54 @@
+.tree {
+    min-height:20px;
+    padding:19px;
+    margin-bottom:20px;
+    background-color:#333333;
+    -webkit-box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.05);
+    -moz-box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.05);
+    box-shadow:inset 0 1px 1px rgba(0, 0, 0, 0.05)
+}
+.tree li {
+    list-style-type:none;
+    margin:0;
+    position:relative
+    margin-bottom:15px;
+}
+.tree li::before, .tree li::after {
+    content:'';
+    left:-20px;
+    position:absolute;
+    right:auto
+}
+.tree li::before {
+    bottom:50px;
+    height:100%;
+    top:0;
+    width:1px
+}
+.tree li::after {
+    height:20px;
+    top:25px;
+    width:25px
+}
+.tree li span {
+    display:inline-block;
+    padding:3px 8px;
+    text-decoration:none
+}
+.tree li.parent_li>span {
+    cursor:pointer
+}
+.tree>ul>li::before, .tree>ul>li::after {
+    border:0
+}
+.tree li:last-child::before {
+    height:70px
+}
+.tree li.parent_li>span:hover, .tree li.parent_li>span:hover+ul li span {
+    background:#eee;
+    border:0px solid #94a0b4;
+    color:#000
+}
+li > label {
+    color:white;
+}

--- a/app/index.html
+++ b/app/index.html
@@ -6,6 +6,7 @@
   <title>Bugz - {{title}}</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700" rel="stylesheet">
   <link rel="stylesheet" href="/compiled/app.min.css">
+  <link rel="stylesheet" type="text/css" href="/css/tree.css">
   <link rel="icon" type="image/png" href="/img/favicon.ico">
 </head>
 <body class="flex-outer">

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -263,6 +263,7 @@ angular.module('myApp.controllers', [])
     '$scope',
     'sprintService',
     function ($scope, sprintService) {
+      $scope.pageTitle = 'Archieved'
       sprintService
         .getArchived()
         .success(function (sprints) {

--- a/app/js/tree.js
+++ b/app/js/tree.js
@@ -1,0 +1,14 @@
+$(function () {
+    $('.tree li:has(ul)').addClass('parent_li').find(' > span').attr('title', 'Collapse this branch');
+    $('.tree li.parent_li > span').on('click', function (e) {
+        var children = $(this).parent('li.parent_li').find(' > ul > li');
+        if (children.is(":visible")) {
+            children.hide('fast');
+            $(this).attr('title', 'Expand this branch').find(' > i').addClass('icon-plus-sign').removeClass('icon-minus-sign');
+        } else {
+            children.show('fast');
+            $(this).attr('title', 'Collapse this branch').find(' > i').addClass('icon-minus-sign').removeClass('icon-plus-sign');
+        }
+        e.stopPropagation();
+    });
+});

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -13,3 +13,4 @@
     <strong>Message Deb(sodeb@redhat.com) for creating sprints.</strong>
   </div>
 </div>
+<script type="text/javascript" src="/js/tree.js"></script>

--- a/app/views/sidebar.html
+++ b/app/views/sidebar.html
@@ -1,5 +1,5 @@
 <ul class="section-sidebar-nav nav nav-stacked">
-  <li ng-show="canEdit(user)">
+  <li ng-show="canEdit(user)" style="display:none">
     <a href="/add"><span class="fa fa-fw fa-plus"></span> Add sprint</a>
   </li>
   <li>
@@ -11,4 +11,33 @@
   <li>
     <a href="/archived"><span class="fa fa-fw fa-book"></span> Archived sprints</a>
   </li>
+  <div style="width:300px;background-color:#333333; padding:20px;">
+    <div style="overflow-x: hidden; height: 500px;">
+        <ul class="section-sidbar-nav nav nav-stacked nav-list">
+            <li><label class="tree-toggler nav-header">Target Release 1</label>
+                <ul class="nav nav-list tree">
+                    <li><a href="#">Alpha</a></li>
+                    <li><a href="#">Beta</a></li>
+                    <li><a href="#">RC</a></li>
+                    <li><a href="#">Final</a></li>
+                </ul>
+            </li>
+            <li><label class="tree-toggler nav-header">Target Release 2</label>
+                <ul class="nav nav-list tree">
+                    <li><a href="#">Alpha</a></li>
+                    <li><a href="#">Beta</a></li>
+                    <li><a href="#">RC</a></li>
+                    <li><a href="#">Final</a></li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+</div>
 </ul>
+<script type="text/javascript">
+  $(document).ready(function () {
+  $('label.tree-toggler').click(function () {
+    $(this).parent().children('ul.tree').toggle(300);
+  });
+});
+</script>


### PR DESCRIPTION
- Adds tree layout of target_release nested with target_milestone in the sidebar.
- Hides the Add sprint option.

SIgned off by: Sudheesh Singanamalla <ssingana@redhat.com>