### PR TITLE
Removing unnecessary google fonts which delays page load on VPN, Fixes #23

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <meta charset="utf-8">
   <title>Bugz - {{title}}</title>
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700" rel="stylesheet">
   <link rel="stylesheet" href="/compiled/app.min.css">
   <link rel="icon" type="image/png" href="/img/favicon.ico">
 </head>


### PR DESCRIPTION
The google fonts that are being used only take the more time to load and at the same time doesn't change the look and feel much. Its much better without.
- Removed the fonts on the page

Signed off by: <ssingana@redhat.com>