### PR TITLE
Fixes issue #35 broken config and angular CSRF after removing oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ You need [nodejs and npm](http://nodejs.org) to install dependencies/build this 
 ## Setup
 
 ```
-$ cp .env.dist .env
 $ npm install
 $ bower install
 $ grunt
@@ -17,7 +16,3 @@ Instead of running `grunt`, run `npm start` instead on production.
 Running `grunt` will make sure your front end assets compile when changed. In case the application is being run as root, run `bower install --allow-root` for installing the bower dependencies. This will create the `sprinter/app/bower_components` which will be used by `grunt` to compile the less files.
 
 Your app should be running at `http://localhost:1337`
-
-## Configuration
-
-We're moving towards not requiring any config file anymore. Most of the config params are deprecated or set to favored defaults.

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -81,9 +81,6 @@ angular.module('myApp', [
       });
 
       $rootScope.canEdit = function canEdit(user) {
-        if (config.dev) {
-          return true;
-        }
         if (!user) {
           return false;
         }

--- a/app/js/services.js
+++ b/app/js/services.js
@@ -29,8 +29,7 @@ angular.module('myApp.services', ['ngResource'])
         });
       };
       service.newBugUrl = function (whiteboard, defaultComponent) {
-        var link = 'https://bugzilla.redhat.com/enter_bug.cgi?product=' + config.bzProduct +
-        '&status_whiteboard=' + encodeURIComponent(whiteboard);
+        var link = 'https://bugzilla.redhat.com/enter_bug.cgi?status_whiteboard=' + encodeURIComponent(whiteboard);
 
         if (defaultComponent) {
           link += ('&component=' + encodeURIComponent(defaultComponent));

--- a/server/app.js
+++ b/server/app.js
@@ -5,11 +5,6 @@ Habitat.load();
 // Configuration
 var env = new Habitat();
 
-// Heroku clearbase support
-if (!env.get('DB_CONNECTIONSTRING') && env.get('cleardbDatabaseUrl')) {
-  env.set('DB_CONNECTIONSTRING', env.get('cleardbDatabaseUrl').replace('?reconnect=true', ''));
-}
-
 // App
 var app = require('./server')(env);
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -10,11 +10,9 @@ module.exports = function(env, app, dbInit, bugzilla, authUri) {
 
   // Serve up virtual configuration "file"
   app.get('/config.js', function (req, res) {
-    var config = env.get('ANGULAR');
 
+    var config = {};
     config.csrf = req.csrfToken();
-    config.bzProduct = env.get('BZ_PRODUCT');
-    config.dev = env.get('DEV');
 
     res.type('js');
     res.send('window.angularConfig = ' + JSON.stringify(config) + ';');


### PR DESCRIPTION
- Removes the environment variables used by habitat which broke during the process of removal of OAuth and .env files in configurations
- Updates the documentation

Signed off by: Sudheesh Singanamalla <ssingana@redhat.com>